### PR TITLE
Allow requiring with a glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ It lets you...
 requires 'any_file', 'with/or/without/extension.rb'
 
 # ...require directories
-requires 'first/directory', 'second-dierectory'
+requires 'first/directory', 'second-directory'
+
+# ...require with a glob
+requires 'base_*', 'directory/*_base'
 
 # ...require any other library
 requires 'yaml', 'lib/important', 'lib'

--- a/lib/requires.rb
+++ b/lib/requires.rb
@@ -6,7 +6,10 @@ def requires(*items)
 
   Dir.chdir base_dir do
     items.each do |item|
-      if File.directory? item
+      if item.include? '*'
+        item += ".rb" unless item.end_with? '.rb'
+        Dir["#{item}"].sort.each { |file| require "./#{file}" }
+      elsif File.directory? item
         Dir["#{item}/**/*.rb"].sort.each { |file| require "./#{file}" }
       elsif File.file? "#{item}.rb" or File.file? item
         require "./#{item}"

--- a/spec/fixtures/glob_with_extension
+++ b/spec/fixtures/glob_with_extension
@@ -1,0 +1,2 @@
+three
+two

--- a/spec/fixtures/glob_without_extension
+++ b/spec/fixtures/glob_without_extension
@@ -1,0 +1,2 @@
+three
+two

--- a/spec/requires/requires_spec.rb
+++ b/spec/requires/requires_spec.rb
@@ -36,4 +36,16 @@ describe 'requires' do
       expect(runner 'multiple_items').to match_fixture "multiple_items"
     end
   end
+
+  context "with a glob pattern that does not end with .rb" do
+    it "requires all matching files" do
+      expect(runner 'glob_without_extension').to match_fixture "glob_without_extension"
+    end
+  end
+
+  context "with a glob pattern that does ends with .rb" do
+    it "requires all matching files" do
+      expect(runner 'glob_with_extension').to match_fixture "glob_with_extension"
+    end
+  end
 end

--- a/spec/runners/glob_with_extension/dir/one.rb
+++ b/spec/runners/glob_with_extension/dir/one.rb
@@ -1,0 +1,1 @@
+puts "one"

--- a/spec/runners/glob_with_extension/dir/three.rb
+++ b/spec/runners/glob_with_extension/dir/three.rb
@@ -1,0 +1,1 @@
+puts "three"

--- a/spec/runners/glob_with_extension/dir/two.rb
+++ b/spec/runners/glob_with_extension/dir/two.rb
@@ -1,0 +1,1 @@
+puts "two"

--- a/spec/runners/glob_with_extension/runner.rb
+++ b/spec/runners/glob_with_extension/runner.rb
@@ -1,0 +1,2 @@
+require 'requires'
+requires 'dir/t*.rb'

--- a/spec/runners/glob_without_extension/dir/one.rb
+++ b/spec/runners/glob_without_extension/dir/one.rb
@@ -1,0 +1,1 @@
+puts "one"

--- a/spec/runners/glob_without_extension/dir/three.rb
+++ b/spec/runners/glob_without_extension/dir/three.rb
@@ -1,0 +1,1 @@
+puts "three"

--- a/spec/runners/glob_without_extension/dir/two.rb
+++ b/spec/runners/glob_without_extension/dir/two.rb
@@ -1,0 +1,1 @@
+puts "two"

--- a/spec/runners/glob_without_extension/runner.rb
+++ b/spec/runners/glob_without_extension/runner.rb
@@ -1,0 +1,2 @@
+require 'requires'
+requires 'dir/t*'


### PR DESCRIPTION
Allow using `requires 'some/glob/pattern*'`