### PR TITLE
Change loading search order to prioritize files over directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Requires
-==================================================
+# Requires
 
 [![Gem Version](https://badge.fury.io/rb/requires.svg)](https://badge.fury.io/rb/requires)
 [![Build Status](https://github.com/DannyBen/requires/workflows/Test/badge.svg)](https://github.com/DannyBen/requires/actions?query=workflow%3ATest)
@@ -27,8 +26,7 @@ Everything is relative to where `requires` is called from.
 ---
 
 
-Installation
---------------------------------------------------
+## Installation
 
     $ gem install requires
 

--- a/lib/requires.rb
+++ b/lib/requires.rb
@@ -9,10 +9,10 @@ def requires(*items)
       if item.include? '*'
         item += ".rb" unless item.end_with? '.rb'
         Dir["#{item}"].sort.each { |file| require "./#{file}" }
-      elsif File.directory? item
-        Dir["#{item}/**/*.rb"].sort.each { |file| require "./#{file}" }
       elsif File.file? "#{item}.rb" or File.file? item
         require "./#{item}"
+      elsif File.directory? item
+        Dir["#{item}/**/*.rb"].sort.each { |file| require "./#{file}" }
       else
         require item
       end

--- a/spec/approvals/matching_dir_and_file
+++ b/spec/approvals/matching_dir_and_file
@@ -1,0 +1,1 @@
+SUCCESS: app script loaded

--- a/spec/requires/requires_spec.rb
+++ b/spec/requires/requires_spec.rb
@@ -48,4 +48,10 @@ describe 'requires' do
       expect(runner 'glob_with_extension').to match_approval "glob_with_extension"
     end
   end
+
+  context "with a path that matches both a directory and a filename" do
+    it "loads the file and not the directory" do
+      expect(runner 'matching_dir_and_file').to match_approval "matching_dir_and_file"
+    end
+  end
 end

--- a/spec/runners/matching_dir_and_file/app.rb
+++ b/spec/runners/matching_dir_and_file/app.rb
@@ -1,0 +1,1 @@
+puts "SUCCESS: app script loaded"

--- a/spec/runners/matching_dir_and_file/app/file.rb
+++ b/spec/runners/matching_dir_and_file/app/file.rb
@@ -1,0 +1,1 @@
+puts "FAILED: dir loaded"

--- a/spec/runners/matching_dir_and_file/runner.rb
+++ b/spec/runners/matching_dir_and_file/runner.rb
@@ -1,0 +1,2 @@
+require 'requires'
+requires 'app'


### PR DESCRIPTION
This PR changes the search order so that in cases where there is a file and a directory with the same name (./app.rb and ./app), the file will be loaded instead of the directory.